### PR TITLE
Fix heading levels on 'Relevant materials' page - trello ticket #329

### DIFF
--- a/web/app/themes/brookhouse/page-research.php
+++ b/web/app/themes/brookhouse/page-research.php
@@ -63,7 +63,7 @@ get_header();
 
         <?= get_field('research_page_intro_text') ?>
 
-        <h4><?php _e('Available publications', '') ?></h4>
+        <h2 class="table-title"><?php _e('Available publications', '') ?></h2>
 
         <?php
         $documents = new WP_Query(

--- a/web/app/themes/brookhouse/style.css
+++ b/web/app/themes/brookhouse/style.css
@@ -383,6 +383,16 @@ body:not(.home) .entry-summary {
     margin: 0 0 1.5em;
 }
 
+.table-title {
+    color: black;
+    font-weight: normal;
+    font-size: 1.1em;
+    border-bottom: 2px solid #666;
+    padding: 2px 0;
+    text-transform: uppercase;
+    margin-bottom: 15px;
+}
+
 
 /* =Asides
 ----------------------------------------------- */


### PR DESCRIPTION
This makes the headings hierarchal, and adds in some CSS to retain the previous styling. This has been tested in Chrome, Firefox and Safari.