### PR TITLE
Create CPT Documents with 3 main taxonomy terms

### DIFF
--- a/web/app/mu-plugins/moj/acf-json/group_5e4c167995338.json
+++ b/web/app/mu-plugins/moj/acf-json/group_5e4c167995338.json
@@ -1,0 +1,159 @@
+{
+    "key": "group_5e4c167995338",
+    "title": "Document information",
+    "fields": [
+        {
+            "key": "field_5e4cfd26442cb",
+            "label": "Document type:",
+            "name": "document_type_to_upload",
+            "type": "select",
+            "instructions": "Choose the type of document you are uploading.",
+            "required": 1,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "Corporate document": "Corporate document",
+                "Media release": "Media release",
+                "Other publication": "Other publication"
+            },
+            "default_value": [],
+            "allow_null": 0,
+            "multiple": 0,
+            "ui": 1,
+            "ajax": 0,
+            "return_format": "value",
+            "placeholder": ""
+        },
+        {
+            "key": "field_5e4cfb542468e",
+            "label": "Corporate document category:",
+            "name": "corporate_document_category",
+            "type": "taxonomy",
+            "instructions": "Choose a category to assign to the document.",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5e4cfd26442cb",
+                        "operator": "==",
+                        "value": "Corporate document"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "taxonomy": "corporate-documents",
+            "field_type": "checkbox",
+            "add_term": 1,
+            "save_terms": 0,
+            "load_terms": 0,
+            "return_format": "id",
+            "multiple": 0,
+            "allow_null": 0
+        },
+        {
+            "key": "field_5e4d3eb55f2fb",
+            "label": "Other publicatins category:",
+            "name": "other_publications_category",
+            "type": "taxonomy",
+            "instructions": "Choose a category to assign to the document.",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5e4cfd26442cb",
+                        "operator": "==",
+                        "value": "Other publication"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "taxonomy": "other-publications",
+            "field_type": "checkbox",
+            "add_term": 1,
+            "save_terms": 0,
+            "load_terms": 0,
+            "return_format": "id",
+            "multiple": 0,
+            "allow_null": 0
+        },
+        {
+            "key": "field_5e4cff09a40b0",
+            "label": "Media releases category:",
+            "name": "media_releases_category",
+            "type": "taxonomy",
+            "instructions": "Choose a category to assign to the document.",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_5e4cfd26442cb",
+                        "operator": "==",
+                        "value": "Media release"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "taxonomy": "media-releases",
+            "field_type": "checkbox",
+            "add_term": 1,
+            "save_terms": 0,
+            "load_terms": 0,
+            "return_format": "id",
+            "multiple": 0,
+            "allow_null": 0
+        },
+        {
+            "key": "field_5e4c169cfb12e",
+            "label": "Upload the document:",
+            "name": "brookhouse_ctp_document_upload",
+            "type": "file",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "return_format": "array",
+            "library": "all",
+            "min_size": "",
+            "max_size": "",
+            "mime_types": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "document"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": 1,
+    "description": "",
+    "modified": 1582120666
+}

--- a/web/app/themes/brookhouse/functions.php
+++ b/web/app/themes/brookhouse/functions.php
@@ -258,6 +258,11 @@ add_action('wp_head', 'add_ie_workarounds');
 require get_template_directory() . '/inc/template-tags.php';
 
 /**
+ * Custom taxonomies
+ */
+require get_template_directory() . '/inc/taxonomies.php';
+
+/**
  * Template redirect rules (hooks to "template_redirect")
  */
 require get_template_directory() . '/inc/template-redirects.php';

--- a/web/app/themes/brookhouse/inc/cpt/cpt-document.php
+++ b/web/app/themes/brookhouse/inc/cpt/cpt-document.php
@@ -51,7 +51,7 @@ function brookhouse_ctp_document_init()
 
     ];
 
-    register_post_type('Document', $args);
+    register_post_type('document', $args);
 }
 
 /**

--- a/web/app/themes/brookhouse/inc/cpt/cpt-document.php
+++ b/web/app/themes/brookhouse/inc/cpt/cpt-document.php
@@ -1,84 +1,73 @@
 <?php
 
+/**
+ * Brookhouse custom post type 'Document'
+ *
+ * @package brookhouse
+ */
+
+/**
+*
+* Register the Document custom post type
+*
+* */
+add_action('init', 'brookhouse_ctp_document_init');
+
 function brookhouse_ctp_document_init()
 {
-    $labels = array(
-        'name' => 'Research',
-        'singular_name' => 'Research item',
+    global $brookhouseTaxonomies;
+
+    $labels = [
+        'name' => 'Documents',
+        'singular_name' => 'Document',
         'add_new' => 'Add New',
         'add_new_item' => 'Add New',
-        'edit_item' => 'Edit Research Entry',
+        'edit_item' => 'Edit Document Entry',
         'new_item' => 'New Entry',
-        'all_items' => 'View All Research',
+        'all_items' => 'View All Documents',
         'view_item' => 'View Entries',
-        'search_items' => 'Search Research',
+        'search_items' => 'Search Document',
         'not_found' => 'No entries found',
-        'not_found_in_trash' => 'No research entries found in Bin',
+        'not_found_in_trash' => 'No Document entries found in Bin',
         'parent_item_colon' => '',
-        'menu_name' => 'Research'
-    );
+        'menu_name' => 'Documents'
+    ];
 
-    $args = array(
+    $args = [
         'labels' => $labels,
         'public' => true,
         'publicly_queryable' => true,
         'show_ui' => true,
         'show_in_menu' => true,
         'query_var' => true,
-        'rewrite' => array('slug' => 'document'),
+        'rewrite' => array('slug' => 'documents'),
         'capability_type' => 'post',
         'has_archive' => false,
         'hierarchical' => false,
         'menu_position' => null,
-        'supports' => array('title')
-    );
+        'menu_icon' => 'dashicons-media-document',
+        'supports' => array('title'),
+        'taxonomies' => $brookhouseTaxonomies
 
-    register_post_type('research', $args);
+    ];
+
+    register_post_type('Document', $args);
 }
-
-add_action('init', 'brookhouse_ctp_document_init');
 
 /**
- * Initialize the meta boxes.
- */
-function brookhouse_add_document_meta_boxes()
-{
-    $document_metabox = array(
-        'id' => 'document_metabox_hearing',
-        'title' => 'Research Details',
-        'pages' => array('research'),
-        'context' => 'normal',
-        'priority' => 'high',
-        'fields' => array(
-            array(
-                'id' => 'document_type',
-                'label' => 'Document Type',
-                'type' => 'select',
-                'choices' => array(
-                    array(
-                        'label' => 'Document',
-                        'value' => 'document'
-                    ),
-                    array (
-                        'label' => 'Ruling',
-                        'value' => 'ruling'
-                    )
-                )
-            ),
-            array(
-                'id' => 'document_date',
-                'label' => 'Document Date',
-                'type' => 'text',
-                'class' => 'datepicker',
-            ),
-            array(
-                'id' => 'document_url',
-                'label' => 'Document URL',
-                'type' => 'upload'
-            )
-        )
-    );
-    ot_register_meta_box($document_metabox);
-}
+*
+* Remove side meta boxes on Document entry admin page - these have been replaced in ACF with ACF fields
+*
+* */
+add_action('do_meta_boxes', 'wpdocs_remove_plugin_metaboxes');
 
-//add_action('admin_init', 'brookhouse_add_document_meta_boxes');
+function wpdocs_remove_plugin_metaboxes()
+{
+    global $brookhouseTaxonomies;
+
+    if (count($brookhouseTaxonomies) > 0) {
+        remove_meta_box('corporate-documentsdiv', 'Document', 'side');
+        remove_meta_box('media-releasesdiv', 'Document', 'side');
+        remove_meta_box('other-publicationsdiv', 'Document', 'side');
+    }
+}

--- a/web/app/themes/brookhouse/inc/taxonomies.php
+++ b/web/app/themes/brookhouse/inc/taxonomies.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * brookhouse taxonomies
+ *
+ * @package brookhouse
+ */
+
+$brookhouseTaxonomies = [
+    'corporate-documents',
+    'media-releases',
+    'other-publications'
+];
+
+/**
+*
+* Register the taxonomies
+*
+* */
+add_action('init', 'brookhouse_create_document_taxonomies');
+
+function brookhouse_create_document_taxonomies()
+{
+    global $brookhouseTaxonomies;
+
+    if (is_array($brookhouseTaxonomies)) {
+        foreach ($brookhouseTaxonomies as $taxonomy) {
+            $taxonomyFriendlyTitle = str_replace('-', ' ', $taxonomy);
+            $taxonomyFriendlyTitle = ucfirst($taxonomyFriendlyTitle);
+
+            $labels = array(
+            'name'              => _x($taxonomyFriendlyTitle, 'taxonomy general name', 'textdomain'),
+            'singular_name'     => _x($taxonomyFriendlyTitle, 'taxonomy singular name', 'textdomain'),
+            'search_items'      => __($taxonomyFriendlyTitle, 'textdomain'),
+            'all_items'         => __('All ' . $taxonomyFriendlyTitle, 'textdomain'),
+            'parent_item'       => __('Parent ' . $taxonomyFriendlyTitle, 'textdomain'),
+            'parent_item_colon' => __('Parent ' . $taxonomyFriendlyTitle, 'textdomain'),
+            'edit_item'         => __('Edit ' . $taxonomyFriendlyTitle, 'textdomain'),
+            'update_item'       => __('Update ' . $taxonomyFriendlyTitle, 'textdomain'),
+            'add_new_item'      => __('Add New ' . $taxonomyFriendlyTitle, 'textdomain'),
+            'new_item_name'     => __('New ' . $taxonomyFriendlyTitle . ' Name', 'textdomain'),
+            'menu_name'         => __($taxonomyFriendlyTitle, 'textdomain'),
+            );
+
+            $args = array(
+            'hierarchical'      => true,
+            'labels'            => $labels,
+            'show_ui'           => true,
+            'show_admin_column' => true,
+            'query_var'         => true,
+            'rewrite'           => array( 'slug' => $taxonomy )
+            );
+
+            register_taxonomy($taxonomy, 'Document', $args);
+        }
+    }
+}


### PR DESCRIPTION
The research post type has been removed and replaced with the Document
cpt. Also, 3 taxonomies have been created to allow for a more refined sorting of documents.