### PR TITLE
Language switcher ACF fix

### DIFF
--- a/web/app/mu-plugins/moj/acf-json/group_5e4d4edd92965.json
+++ b/web/app/mu-plugins/moj/acf-json/group_5e4d4edd92965.json
@@ -27,7 +27,7 @@
             {
                 "param": "nav_menu_item",
                 "operator": "==",
-                "value": "3"
+                "value": "location\/languages-menu"
             }
         ]
     ],
@@ -39,5 +39,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1582135992
+    "modified": 1582297700
 }

--- a/web/app/themes/brookhouse/assets/css/footer.css
+++ b/web/app/themes/brookhouse/assets/css/footer.css
@@ -4,7 +4,7 @@
 
 .menu-languages-container .menu-item {
   display: inline-block;
-  padding: 1rem;
+  padding: 1rem 2rem;
 }
 
 .menu-languages-container #menu-languages {


### PR DESCRIPTION
Fixes issue where ACF fields for language menu items weren't appearing on dev language menu. 

This was because it was previously dependent on the menu id, which was a number that was different locally to dev. Switching it to be based on location instead, which won't change across environments.