### PR TITLE
Update header languages option to anchor link to footer

### DIFF
--- a/web/app/themes/brookhouse/footer.php
+++ b/web/app/themes/brookhouse/footer.php
@@ -12,7 +12,7 @@
 
 <?php wp_nav_menu(array('theme_location' => 'languages-menu')); ?>
 
-<footer id="colophon" class="site-footer">
+<footer id="footer" class="site-footer">
     <div id="footer-nav" class="flex-grid">
         <div class="col">
             <?php

--- a/web/app/themes/brookhouse/header.php
+++ b/web/app/themes/brookhouse/header.php
@@ -56,16 +56,7 @@ $moj_bh_phone_number_link = prepend_country_code_to_number($moj_bh_phone_number)
             </div>
 
             <div class="bh-languages col">
-                <ul data-locale="<?= get_locale() ?>">
-                    <li data-locale="en_GB"><a href="<?= moj_get_page_uri() ?>/?locale=en_GB">English (UK)</a></li>
-                    <li data-locale="ar"><a href="<?= moj_get_page_uri() ?>/?locale=ar" lang="ar"
-                                            class="locale-text-enlarge">عربى</a></li>
-                    <li data-locale="ur"><a href="<?= moj_get_page_uri() ?>/?locale=ur" lang="ur"
-                                            class="locale-text-enlarge">اردو</a></li>
-                    <li data-locale="fa_IR"><a href="<?= moj_get_page_uri() ?>/?locale=fa_IR" lang="fa_IR"
-                                               class="locale-text-enlarge">فارسی</a></li>
-                    <li data-locale="sq"><a href="<?= moj_get_page_uri() ?>/?locale=sq" lang="sq">Shqiptar</a></li>
-                </ul>
+                <a href="#menu-languages">Languages</a>
             </div>
         </div>
     </header><!-- #masthead -->


### PR DESCRIPTION
This removes the list of languages that switched the page language from the header, and replaces it with a link that takes you to the languages menu in the footer.