### PR TITLE
Add in action hook so banner is outside head

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "browscap/browscap-php": "^4.2",
         "piwik/device-detector": "^3.11",
         "ministryofjustice/wp-moj-components": "*",
-        "ministryofjustice/cookie-compliance-for-wordpress": "*"
+        "ministryofjustice/cookie-compliance-for-wordpress": "dev-justice-jobs#c6d762b927ae885fc98533093f8f90524b5fbbe8"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c75b951dcb7f5ad8adfe74aa991546db",
+    "content-hash": "5e2c084759d1b766494c4284e506ef54",
     "packages": [
         {
             "name": "acf/advanced-custom-fields-pro",
@@ -718,17 +718,17 @@
         },
         {
             "name": "ministryofjustice/cookie-compliance-for-wordpress",
-            "version": "1.3.2",
+            "version": "dev-justice-jobs",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ministryofjustice/cookie-compliance-for-wordpress.git",
-                "reference": "cb04cfb9e912d780f176747dbd6796fb0741f738"
+                "reference": "c6d762b927ae885fc98533093f8f90524b5fbbe8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://composer.wp.dsd.io/dist/ministryofjustice/cookie-compliance-for-wordpress/ministryofjustice-cookie-compliance-for-wordpress-cb04cfb9e912d780f176747dbd6796fb0741f738-zip-d7164c.zip",
-                "reference": "cb04cfb9e912d780f176747dbd6796fb0741f738",
-                "shasum": "0c89ea4ab1046876a0aeed7c11377f46aa1e045c"
+                "url": "https://api.github.com/repos/ministryofjustice/cookie-compliance-for-wordpress/zipball/c6d762b927ae885fc98533093f8f90524b5fbbe8",
+                "reference": "c6d762b927ae885fc98533093f8f90524b5fbbe8",
+                "shasum": ""
             },
             "require": {
                 "composer/installers": "^1.0"
@@ -753,10 +753,10 @@
             ],
             "description": "WP plugin that presents visitor with a cookie consent banner and opt-out setting page.",
             "support": {
-                "source": "https://github.com/ministryofjustice/cookie-compliance-for-wordpress/tree/1.3.2",
+                "source": "https://github.com/ministryofjustice/cookie-compliance-for-wordpress/tree/justice-jobs",
                 "issues": "https://github.com/ministryofjustice/cookie-compliance-for-wordpress/issues"
             },
-            "time": "2019-12-23T20:06:00+00:00"
+            "time": "2020-02-21T14:13:09+00:00"
         },
         {
             "name": "ministryofjustice/wp-moj-components",
@@ -2192,7 +2192,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "ministryofjustice/cookie-compliance-for-wordpress": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/web/app/themes/brookhouse/header.php
+++ b/web/app/themes/brookhouse/header.php
@@ -8,13 +8,14 @@
  * @package brookhouse
  */
 
-
 // contact telephone number
 $moj_bh_phone_number = get_field('telephone_number', 'option');
 $moj_bh_phone_number_link = prepend_country_code_to_number($moj_bh_phone_number);
 
-?><!DOCTYPE html>
+?>
+<!DOCTYPE html>
 <html <?php language_attributes(); ?>>
+
 <head>
     <meta charset="<?php bloginfo('charset'); ?>">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -26,6 +27,15 @@ $moj_bh_phone_number_link = prepend_country_code_to_number($moj_bh_phone_number)
 </head>
 
 <body <?php body_class('locale-' . get_locale()); ?>>
+
+    <?php
+
+/**
+ * MoJ hook in our themes to allow content to be hooked and placed
+ * at the top of the page but still within the body
+ *  */
+do_action('after_body_open_tag'); ?>
+
 <div id="page" class="hfeed site">
     <?php do_action('before'); ?>
     <nav id="site-navigation" class="main-navigation">
@@ -48,8 +58,8 @@ $moj_bh_phone_number_link = prepend_country_code_to_number($moj_bh_phone_number)
                 <div class="site-header__phone-number">
                     <a href="tel:<?= $moj_bh_phone_number_link ?>">
                         <img class="site-header__phone-number--image"
-                             src="<?php echo get_template_directory_uri(); ?>/dist/img/call-for-info.svg"
-                             alt="Call with information regarding the Brook House Investigation">
+                            src="<?php echo get_template_directory_uri(); ?>/dist/img/call-for-info.svg"
+                            alt="Call with information regarding the Brook House Investigation">
                         <span class="site-header__phone-number--text"><?= $moj_bh_phone_number ?></span>
                     </a>
                 </div>
@@ -61,12 +71,14 @@ $moj_bh_phone_number_link = prepend_country_code_to_number($moj_bh_phone_number)
         </div>
     </header><!-- #masthead -->
     <?php if (is_front_page()) { ?>
-        <section id="tagline">
-            <div class="site-branding tagline">
-                <?php _e('An independent investigation into the potential mistreatment of detainees at Brook House IRC in 2017',
-                    'brookhouse'); ?>
-            </div>
-        </section>
+    <section id="tagline">
+        <div class="site-branding tagline">
+            <?php _e(
+                'An independent investigation into the potential mistreatment of detainees at Brook House IRC in 2017',
+                'brookhouse'
+            ); ?>
+        </div>
+    </section>
     <?php } ?>
     <section id="breadcrumbs-wrapper">
         <div id="breadcrumbs">
@@ -75,57 +87,57 @@ $moj_bh_phone_number_link = prepend_country_code_to_number($moj_bh_phone_number)
                     <a href="<?php echo esc_url(home_url('/')); ?>" rel="home">Home</a>
                 </li>
                 <?php
-                if (!is_home() && $post != null) {
-                    foreach (get_post_ancestors($post->ID) as $ancestor_id) {
-                        echo "<li class='breadcrumb-child'><a href='" . get_permalink($ancestor_id) . "'>" . get_the_title($ancestor_id) . "</a></li>";
-                    }
+            if (!is_home() && $post != null) {
+                foreach (get_post_ancestors($post->ID) as $ancestor_id) {
+                    echo "<li class='breadcrumb-child'><a href='" . get_permalink($ancestor_id) . "'>" . get_the_title($ancestor_id) . "</a></li>";
+                }
 
-                    if (is_archive()) {
+                if (is_archive()) {
+                    echo "<li class='breadcrumb-child'><a href='" .
+                        get_post_type_archive_link(
+                            $wp_query->query['post_type']
+                        ) . "'>" .
+                        post_type_archive_title(
+                            '',
+                            false
+                        ) . "</a></li> ";
+                    if (is_post_type_archive('evidence') && get_query_var('witness')) {
+                        $witness = get_term_by('slug', get_query_var("witness"), "witness");
                         echo "<li class='breadcrumb-child'><a href='" .
-                            get_post_type_archive_link(
-                                $wp_query->query['post_type']
-                            ) . "'>" .
-                            post_type_archive_title(
-                                '',
-                                false
-                            ) . "</a></li> ";
-                        if (is_post_type_archive('evidence') && get_query_var('witness')) {
-                            $witness = get_term_by('slug', get_query_var("witness"), "witness");
-                            echo "<li class='breadcrumb-child'><a href='" .
-                                get_permalink(
-                                    get_page_by_title(
-                                        'evidence'
-                                    )
-                                ) . "?witness=" . get_query_var('witness') . "'> Witness: " . $witness->name . "</a></li>";
-                        } elseif (is_post_type_archive('evidence') && get_query_var('hdate')) {
-                            echo "<li class='breadcrumb-child'><a href='" .
-                                get_permalink(
-                                    get_page_by_title(
-                                        'evidence'
-                                    )
-                                ) . "?hdate=" .
-                                get_query_var(
-                                    'hdate'
-                                ) . "'> Date: " .
-                                date(
-                                    'l j F Y',
-                                    strtotime($_GET['hdate'])
-                                ) . "</a></li>";
-                        }
+                            get_permalink(
+                                get_page_by_title(
+                                    'evidence'
+                                )
+                            ) . "?witness=" . get_query_var('witness') . "'> Witness: " . $witness->name . "</a></li>";
+                    } elseif (is_post_type_archive('evidence') && get_query_var('hdate')) {
+                        echo "<li class='breadcrumb-child'><a href='" .
+                            get_permalink(
+                                get_page_by_title(
+                                    'evidence'
+                                )
+                            ) . "?hdate=" .
+                            get_query_var(
+                                'hdate'
+                            ) . "'> Date: " .
+                            date(
+                                'l j F Y',
+                                strtotime($_GET['hdate'])
+                            ) . "</a></li>";
+                    }
+                } else {
+                    if (is_search()) {
+                        echo "<li class='breadcrumb-child'>Search Results for: " . get_search_query() . "</li>";
                     } else {
-                        if (is_search()) {
-                            echo "<li class='breadcrumb-child'>Search Results for: " . get_search_query() . "</li>";
-                        } else {
-                            if (is_singular('hearing')) {
-                                echo "<li class='breadcrumb-child'><a href='" . get_permalink(get_page_by_title('hearings')) . "'>Hearings</a> </li>";
-                            }
-                            echo "<li class='breadcrumb-child'><a href='" . get_permalink() . "'>" . get_the_title() . "</a></li>";
+                        if (is_singular('hearing')) {
+                            echo "<li class='breadcrumb-child'><a href='" . get_permalink(get_page_by_title('hearings')) . "'>Hearings</a> </li>";
                         }
+                        echo "<li class='breadcrumb-child'><a href='" . get_permalink() . "'>" . get_the_title() . "</a></li>";
                     }
                 }
-                ?>
+            }
+            ?>
             </ul>
         </div>
     </section>
 
-    <div id="content" class="site-content">
+<div id="content" class="site-content">

--- a/web/app/themes/brookhouse/header.php
+++ b/web/app/themes/brookhouse/header.php
@@ -34,110 +34,110 @@ $moj_bh_phone_number_link = prepend_country_code_to_number($moj_bh_phone_number)
  * MoJ hook in our themes to allow content to be hooked and placed
  * at the top of the page but still within the body
  *  */
-do_action('after_body_open_tag'); ?>
+    do_action('after_body_open_tag'); ?>
 
-<div id="page" class="hfeed site">
-    <?php do_action('before'); ?>
-    <nav id="site-navigation" class="main-navigation">
-        <button id="nav-icon" class="menu-toggle">
-            <span>&nbsp;</span>
-            <span>&nbsp;</span>
-            <span>&nbsp;</span>
-            <div style="display:none">Open navigation</div>
-        </button>
-        <a class="skip-link screen-reader-text" href="#content"><?php _e('Skip to content', 'brookhouse'); ?></a>
-    </nav><!-- #site-navigation -->
-    <header id="masthead" class="site-header">
-        <div class="site-branding flex-grid">
-            <div class="col branding">
-                <a href="<?= esc_url(home_url('/')); ?>" rel="home" class="site-header__logo">
-                    <img src="<?= get_template_directory_uri(); ?>/dist/img/brookhouse-logo.svg"
-                        alt="<?php bloginfo('name'); ?>">
-                </a>
-
-                <div class="site-header__phone-number">
-                    <a href="tel:<?= $moj_bh_phone_number_link ?>">
-                        <img class="site-header__phone-number--image"
-                            src="<?php echo get_template_directory_uri(); ?>/dist/img/call-for-info.svg"
-                            alt="Call with information regarding the Brook House Investigation">
-                        <span class="site-header__phone-number--text"><?= $moj_bh_phone_number ?></span>
+    <div id="page" class="hfeed site">
+        <?php do_action('before'); ?>
+        <nav id="site-navigation" class="main-navigation">
+            <button id="nav-icon" class="menu-toggle">
+                <span>&nbsp;</span>
+                <span>&nbsp;</span>
+                <span>&nbsp;</span>
+                <div style="display:none">Open navigation</div>
+            </button>
+            <a class="skip-link screen-reader-text" href="#content"><?php _e('Skip to content', 'brookhouse'); ?></a>
+        </nav><!-- #site-navigation -->
+        <header id="masthead" class="site-header">
+            <div class="site-branding flex-grid">
+                <div class="col branding">
+                    <a href="<?= esc_url(home_url('/')); ?>" rel="home" class="site-header__logo">
+                        <img src="<?= get_template_directory_uri(); ?>/dist/img/brookhouse-logo.svg"
+                            alt="<?php bloginfo('name'); ?>">
                     </a>
+
+                    <div class="site-header__phone-number">
+                        <a href="tel:<?= $moj_bh_phone_number_link ?>">
+                            <img class="site-header__phone-number--image"
+                                src="<?php echo get_template_directory_uri(); ?>/dist/img/call-for-info.svg"
+                                alt="Call with information regarding the Brook House Investigation">
+                            <span class="site-header__phone-number--text"><?= $moj_bh_phone_number ?></span>
+                        </a>
+                    </div>
+                </div>
+
+                <div class="bh-languages col">
+                    <a href="#menu-languages">Languages</a>
                 </div>
             </div>
-
-            <div class="bh-languages col">
-                <a href="#menu-languages">Languages</a>
+        </header><!-- #masthead -->
+        <?php if (is_front_page()) { ?>
+        <section id="tagline">
+            <div class="site-branding tagline">
+                <?php _e(
+                    'An independent investigation into the potential mistreatment of detainees at Brook House IRC in 2017',
+                    'brookhouse'
+                ); ?>
             </div>
-        </div>
-    </header><!-- #masthead -->
-    <?php if (is_front_page()) { ?>
-    <section id="tagline">
-        <div class="site-branding tagline">
-            <?php _e(
-                'An independent investigation into the potential mistreatment of detainees at Brook House IRC in 2017',
-                'brookhouse'
-            ); ?>
-        </div>
-    </section>
-    <?php } ?>
-    <section id="breadcrumbs-wrapper">
-        <div id="breadcrumbs">
-            <ul>
-                <li>
-                    <a href="<?php echo esc_url(home_url('/')); ?>" rel="home">Home</a>
-                </li>
-                <?php
-            if (!is_home() && $post != null) {
-                foreach (get_post_ancestors($post->ID) as $ancestor_id) {
-                    echo "<li class='breadcrumb-child'><a href='" . get_permalink($ancestor_id) . "'>" . get_the_title($ancestor_id) . "</a></li>";
-                }
-
-                if (is_archive()) {
-                    echo "<li class='breadcrumb-child'><a href='" .
-                        get_post_type_archive_link(
-                            $wp_query->query['post_type']
-                        ) . "'>" .
-                        post_type_archive_title(
-                            '',
-                            false
-                        ) . "</a></li> ";
-                    if (is_post_type_archive('evidence') && get_query_var('witness')) {
-                        $witness = get_term_by('slug', get_query_var("witness"), "witness");
-                        echo "<li class='breadcrumb-child'><a href='" .
-                            get_permalink(
-                                get_page_by_title(
-                                    'evidence'
-                                )
-                            ) . "?witness=" . get_query_var('witness') . "'> Witness: " . $witness->name . "</a></li>";
-                    } elseif (is_post_type_archive('evidence') && get_query_var('hdate')) {
-                        echo "<li class='breadcrumb-child'><a href='" .
-                            get_permalink(
-                                get_page_by_title(
-                                    'evidence'
-                                )
-                            ) . "?hdate=" .
-                            get_query_var(
-                                'hdate'
-                            ) . "'> Date: " .
-                            date(
-                                'l j F Y',
-                                strtotime($_GET['hdate'])
-                            ) . "</a></li>";
-                    }
-                } else {
-                    if (is_search()) {
-                        echo "<li class='breadcrumb-child'>Search Results for: " . get_search_query() . "</li>";
-                    } else {
-                        if (is_singular('hearing')) {
-                            echo "<li class='breadcrumb-child'><a href='" . get_permalink(get_page_by_title('hearings')) . "'>Hearings</a> </li>";
+        </section>
+        <?php } ?>
+        <section id="breadcrumbs-wrapper">
+            <div id="breadcrumbs">
+                <ul>
+                    <li>
+                        <a href="<?php echo esc_url(home_url('/')); ?>" rel="home">Home</a>
+                    </li>
+                    <?php
+                    if (!is_home() && $post != null) {
+                        foreach (get_post_ancestors($post->ID) as $ancestor_id) {
+                            echo "<li class='breadcrumb-child'><a href='" . get_permalink($ancestor_id) . "'>" . get_the_title($ancestor_id) . "</a></li>";
                         }
-                        echo "<li class='breadcrumb-child'><a href='" . get_permalink() . "'>" . get_the_title() . "</a></li>";
-                    }
-                }
-            }
-            ?>
-            </ul>
-        </div>
-    </section>
 
-<div id="content" class="site-content">
+                        if (is_archive()) {
+                            echo "<li class='breadcrumb-child'><a href='" .
+                                get_post_type_archive_link(
+                                    $wp_query->query['post_type']
+                                ) . "'>" .
+                                post_type_archive_title(
+                                    '',
+                                    false
+                                ) . "</a></li> ";
+                            if (is_post_type_archive('evidence') && get_query_var('witness')) {
+                                $witness = get_term_by('slug', get_query_var("witness"), "witness");
+                                echo "<li class='breadcrumb-child'><a href='" .
+                                    get_permalink(
+                                        get_page_by_title(
+                                            'evidence'
+                                        )
+                                    ) . "?witness=" . get_query_var('witness') . "'> Witness: " . $witness->name . "</a></li>";
+                            } elseif (is_post_type_archive('evidence') && get_query_var('hdate')) {
+                                echo "<li class='breadcrumb-child'><a href='" .
+                                    get_permalink(
+                                        get_page_by_title(
+                                            'evidence'
+                                        )
+                                    ) . "?hdate=" .
+                                    get_query_var(
+                                        'hdate'
+                                    ) . "'> Date: " .
+                                    date(
+                                        'l j F Y',
+                                        strtotime($_GET['hdate'])
+                                    ) . "</a></li>";
+                            }
+                        } else {
+                            if (is_search()) {
+                                echo "<li class='breadcrumb-child'>Search Results for: " . get_search_query() . "</li>";
+                            } else {
+                                if (is_singular('hearing')) {
+                                    echo "<li class='breadcrumb-child'><a href='" . get_permalink(get_page_by_title('hearings')) . "'>Hearings</a> </li>";
+                                }
+                                echo "<li class='breadcrumb-child'><a href='" . get_permalink() . "'>" . get_the_title() . "</a></li>";
+                            }
+                        }
+                    }
+                    ?>
+                </ul>
+            </div>
+        </section>
+
+        <div id="content" class="site-content">

--- a/web/app/themes/brookhouse/package-lock.json
+++ b/web/app/themes/brookhouse/package-lock.json
@@ -10565,9 +10565,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.26.0.tgz",
-      "integrity": "sha512-akOxgCUOjRtBUgKiWVYrUxKnDIN5+z/m7NKmav5RU9q4oXMVAXYStn1pXvTECyTIe6WupElREKgDRbFvHb2anA==",
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.26.1.tgz",
+      "integrity": "sha512-DWtzW0jDu+96MYkEdM8vUigjpisvM9qSlDwNvTFcr+XC7o2+3aXSAbHNcJ+8HzD1857uW9Opbxgu39esytVUKA==",
       "dev": true,
       "requires": {
         "chokidar": ">=2.0.0 <4.0.0"

--- a/web/app/themes/brookhouse/package.json
+++ b/web/app/themes/brookhouse/package.json
@@ -34,8 +34,8 @@
         "laravel-mix-svg": "^0.4.1",
         "node-sass": "^4.13.1",
         "resolve-url-loader": "^3.1.0",
-        "sass": "^1.23.7",
-        "sass-loader": "^7.1.0",
+        "sass": "^1.26.1",
+        "sass-loader": "^7.3.1",
         "vue-template-compiler": "^2.6.11"
     }
 }


### PR DESCRIPTION
In order to keep the banner at the top of the page but out of Head, as per Rob's work on JJ, we are adding in an action hook.
Also
Updated NPM. 
Updated Composer to pull latest versions and branch of JJ cookie banner. Requires the commit hash appending to the branch name in order to grab the latest commit.
Format to HTML & PSR12.