### PR TITLE
Header Banner can now be edited from the WP backend

### DIFF
--- a/web/app/mu-plugins/moj/acf-json/group_5e59267fb5b97.json
+++ b/web/app/mu-plugins/moj/acf-json/group_5e59267fb5b97.json
@@ -1,0 +1,43 @@
+{
+    "key": "group_5e59267fb5b97",
+    "title": "Header Banner",
+    "fields": [
+        {
+            "key": "field_5e592694f74f6",
+            "label": "Header Banner Text",
+            "name": "header_banner_text",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "page_type",
+                "operator": "==",
+                "value": "front_page"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": 1,
+    "description": "",
+    "modified": 1582904029
+}

--- a/web/app/themes/brookhouse/header.php
+++ b/web/app/themes/brookhouse/header.php
@@ -70,16 +70,21 @@ $moj_bh_phone_number_link = prepend_country_code_to_number($moj_bh_phone_number)
                 </div>
             </div>
         </header><!-- #masthead -->
-        <?php if (is_front_page()) { ?>
-        <section id="tagline">
-            <div class="site-branding tagline">
-                <?php _e(
-                    'An independent investigation into the potential mistreatment of detainees at Brook House IRC in 2017',
-                    'brookhouse'
-                ); ?>
-            </div>
-        </section>
-        <?php } ?>
+        <?php if (is_front_page()) {
+
+            $banner_text  = get_field('header_banner_text');
+
+            if(!empty($banner_text)){
+            ?>
+                <section id="tagline">
+                    <div class="site-branding tagline">
+                        <?php echo $banner_text; ?>
+                    </div>
+                </section>
+             <?php
+                }
+            }
+            ?>
         <section id="breadcrumbs-wrapper">
             <div id="breadcrumbs">
                 <ul>


### PR DESCRIPTION
Header Banner can now be edited from backend
I have made this a separate banner acf field (shown only when editing the front page) rather then bundle it with the homepage content fields should we wish to use the banner on other pages at a later date. As technically its not in the homepage template its in the header.