### PR TITLE
Switch anchor link href from content to main

### DIFF
--- a/web/app/themes/brookhouse/header.php
+++ b/web/app/themes/brookhouse/header.php
@@ -47,7 +47,7 @@ $moj_bh_header_link = get_field('header_link', 'option');
                 <span>&nbsp;</span>
                 <div style="display:none">Open navigation</div>
             </button>
-            <a class="skip-link screen-reader-text" href="#content"><?php _e('Skip to content', 'brookhouse'); ?></a>
+            <a class="skip-link screen-reader-text" href="#main"><?php _e('Skip to content', 'brookhouse'); ?></a>
         </nav><!-- #site-navigation -->
         <header id="masthead" class="site-header">
             <div class="site-branding flex-grid">


### PR DESCRIPTION
The `href` of the skip link previously pointed to `#content`, which contained the nav bar - but the purpose of the 'skip to main content' link is to allow you to bypass nav bars and get to the main content. This changes the `href` to point at `#main`, which is where the main content starts.

This addresses ticket #676 on Trello.