### PR TITLE
Allow entry of the language code of page content

### DIFF
--- a/web/app/mu-plugins/moj/acf-json/group_5e78f5d395ff9.json
+++ b/web/app/mu-plugins/moj/acf-json/group_5e78f5d395ff9.json
@@ -1,0 +1,43 @@
+{
+    "key": "group_5e78f5d395ff9",
+    "title": "Page language",
+    "fields": [
+        {
+            "key": "field_5e78f5e593c91",
+            "label": "page-language",
+            "name": "page-language",
+            "type": "text",
+            "instructions": "If you're entering text in a different language, enter that language's language code here. If it's English, leave this blank.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "page_template",
+                "operator": "==",
+                "value": "default"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "acf_after_title",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": 1,
+    "description": "",
+    "modified": 1584986307
+}

--- a/web/app/themes/brookhouse/page.php
+++ b/web/app/themes/brookhouse/page.php
@@ -20,10 +20,26 @@ get_sidebar();
 
         <?php while (have_posts()) :
             the_post(); ?>
+
+            <?php
+                $page_lang = get_field('page-language');
+                if (!empty($page_lang)) { ?>
+                    <div lang="<?php echo $page_lang; ?>">
+                    <?php
+                }
+            ?>
+
             <?php get_template_part('content', 'page'); ?>
             <?php get_template_part('components/cta-section'); ?>
+
+            <?php
+                if (!empty($page_lang)) { ?>
+                    </div>
+                    <?php
+                }
+            ?>
         <?php endwhile; // end of the loop. ?>
-        
+
     </main><!-- #main -->
 </div><!-- #primary -->
 


### PR DESCRIPTION
We have a few pages that are in a different language. This allows us to set the `lang` attribute for this content, on a page-per-page basis (for default pages).

This relates to ticket #745 on our trello board.