### PR TITLE
Fix issue where phone icon was expanding horizontally in IE11

### DIFF
--- a/web/app/themes/brookhouse/assets/scss/header.scss
+++ b/web/app/themes/brookhouse/assets/scss/header.scss
@@ -78,6 +78,7 @@
 
       &--image {
         max-height: 4rem;
+        max-width: 4rem;
         vertical-align: bottom;
       }
 


### PR DESCRIPTION
The phone logo was expanding horizontally in Internet Explorer, which was distorting it and interfering with the layout:

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/16868713/78558979-77511f80-780b-11ea-811e-2627a4b5323a.png">

This PR fixes that.