### PR TITLE
Empty evidence page

### DIFF
--- a/web/app/themes/brookhouse/assets/js/evidence.js
+++ b/web/app/themes/brookhouse/assets/js/evidence.js
@@ -5,7 +5,6 @@ jQuery(document).ready(function ($) {
 
   if (evidencePage.length) {
 
-    console.log(evidencePage);
     document.getElementById('js-evidence-filter').style.display = "block";
     document.getElementById('js-turned-off').style.display = "none";
 

--- a/web/app/themes/brookhouse/assets/js/evidence.js
+++ b/web/app/themes/brookhouse/assets/js/evidence.js
@@ -1,79 +1,83 @@
 /* This is based off of Heydon Pickering's Inclusive Components:
   https://inclusive-components.design/cards/
 */
+const evidencePage = document.querySelector('.evidence-main');
 
-const cards = document.querySelectorAll('.js-evidence-item');
-Array.prototype.forEach.call(cards, card => {
-  card.setAttribute("style", "cursor: pointer;");
-  let down, up, link = card.querySelector('a');
-  card.onmousedown = () => down = +new Date();
-  card.onmouseup = () => {
+if (evidencePage) {
+
+  const cards = document.querySelectorAll('.js-evidence-item');
+  Array.prototype.forEach.call(cards, card => {
+    card.setAttribute("style", "cursor: pointer;");
+    let down, up, link = card.querySelector('a');
+    card.onmousedown = () => down = +new Date();
+    card.onmouseup = () => {
       up = +new Date();
       if ((up - down) < 200) {
-          link.click();
-      }
-  }
-});
-
-// JavaScript is enabled, so the no JS-warning is removed
-document.getElementById('js-evidence-filter').style.display = "block";
-document.getElementById('js-turned-off').style.display = "none";
-
-jQuery(document).ready(function ($) {
-
-  var checkedValues = [];
-
-  // Initial check to see if any are already checked on page load
-  $('input[type=checkbox]').each(function () {
-    if ($(this).prop("checked") == true) {
-      var value = $(this).val();
-      checkedValues.push(value);
-
-      // Now the array is up to date, this toggles what's shown
-      if (checkedValues.length) {
-        $('.evidence__item').hide();
-        checkedValues.forEach(function (entry) {
-          $('.evidence__item[data-evidence-type="' + entry + '"]').show();
-          $('.evidence__item[data-evidence-format="' + entry + '"]').show();
-          $('.evidence__item[data-witness-type="' + entry + '"]').show();
-        });
+        link.click();
       }
     }
-  })
+  });
 
-  if ($('#js-evidence-filter').length) {
-    $('input[type=checkbox]').change(function () {
-      $('input[type=checkbox]').each(function () {
-        // Checks if it's already there and if it is, removes it
-        if ($(this).prop("checked")) {
-          var value = $(this).val();
-          var index = checkedValues.indexOf(value);
-          if (index > -1) {
-            checkedValues.splice(index, 1);
-          }
-          checkedValues.push(value);
-        }
-        // Otherwise, if it's not in the list of things checked anymore, it removes it
-        else {
-          var value = $(this).val();
-          var index = checkedValues.indexOf(value);
-          if (index > -1) {
-            checkedValues.splice(index, 1);
-          }
-        }
-      })
+  // JavaScript is enabled, so the no JS-warning is removed
+  document.getElementById('js-evidence-filter').style.display = "block";
+  document.getElementById('js-turned-off').style.display = "none";
 
-      // Now the array is up to date, this toggles what's shown
-      if (checkedValues.length) {
-        $('.evidence__item').hide();
-        checkedValues.forEach(function (entry) {
-          $('.evidence__item[data-evidence-type="' + entry + '"]').show();
-          $('.evidence__item[data-evidence-format="' + entry + '"]').show();
-          $('.evidence__item[data-witness-type="' + entry + '"]').show();
-        });
-      } else {
-        $('.evidence__item').show();
+  jQuery(document).ready(function ($) {
+
+    var checkedValues = [];
+
+    // Initial check to see if any are already checked on page load
+    $('input[type=checkbox]').each(function () {
+      if ($(this).prop("checked") == true) {
+        var value = $(this).val();
+        checkedValues.push(value);
+
+        // Now the array is up to date, this toggles what's shown
+        if (checkedValues.length) {
+          $('.evidence__item').hide();
+          checkedValues.forEach(function (entry) {
+            $('.evidence__item[data-evidence-type="' + entry + '"]').show();
+            $('.evidence__item[data-evidence-format="' + entry + '"]').show();
+            $('.evidence__item[data-witness-type="' + entry + '"]').show();
+          });
+        }
       }
-    });
-  }
-});
+    })
+
+    if ($('#js-evidence-filter').length) {
+      $('input[type=checkbox]').change(function () {
+        $('input[type=checkbox]').each(function () {
+          // Checks if it's already there and if it is, removes it
+          if ($(this).prop("checked")) {
+            var value = $(this).val();
+            var index = checkedValues.indexOf(value);
+            if (index > -1) {
+              checkedValues.splice(index, 1);
+            }
+            checkedValues.push(value);
+          }
+          // Otherwise, if it's not in the list of things checked anymore, it removes it
+          else {
+            var value = $(this).val();
+            var index = checkedValues.indexOf(value);
+            if (index > -1) {
+              checkedValues.splice(index, 1);
+            }
+          }
+        })
+
+        // Now the array is up to date, this toggles what's shown
+        if (checkedValues.length) {
+          $('.evidence__item').hide();
+          checkedValues.forEach(function (entry) {
+            $('.evidence__item[data-evidence-type="' + entry + '"]').show();
+            $('.evidence__item[data-evidence-format="' + entry + '"]').show();
+            $('.evidence__item[data-witness-type="' + entry + '"]').show();
+          });
+        } else {
+          $('.evidence__item').show();
+        }
+      });
+    }
+  });
+}

--- a/web/app/themes/brookhouse/assets/js/evidence.js
+++ b/web/app/themes/brookhouse/assets/js/evidence.js
@@ -1,28 +1,34 @@
-/* This is based off of Heydon Pickering's Inclusive Components:
-  https://inclusive-components.design/cards/
-*/
-const evidencePage = document.querySelector('.evidence-main');
+// JavaScript is enabled, so the no JS-warning is removed
 
-if (evidencePage) {
+jQuery(document).ready(function ($) {
+  const evidencePage = $(".evidence-main");
 
-  const cards = document.querySelectorAll('.js-evidence-item');
-  Array.prototype.forEach.call(cards, card => {
-    card.setAttribute("style", "cursor: pointer;");
-    let down, up, link = card.querySelector('a');
-    card.onmousedown = () => down = +new Date();
-    card.onmouseup = () => {
-      up = +new Date();
-      if ((up - down) < 200) {
-        link.click();
+  if (evidencePage.length) {
+
+    console.log(evidencePage);
+    document.getElementById('js-evidence-filter').style.display = "block";
+    document.getElementById('js-turned-off').style.display = "none";
+
+
+    /* This is based off of Heydon Pickering's Inclusive Components:
+      https://inclusive-components.design/cards/
+    */
+
+    const cards = document.querySelectorAll('.js-evidence-item');
+    Array.prototype.forEach.call(cards, card => {
+      card.setAttribute("style", "cursor: pointer;");
+      let down, up, link = card.querySelector('a');
+      card.onmousedown = () => down = +new Date();
+      card.onmouseup = () => {
+        up = +new Date();
+        if ((up - down) < 200) {
+          link.click();
+        }
       }
-    }
-  });
+    });
 
-  // JavaScript is enabled, so the no JS-warning is removed
-  document.getElementById('js-evidence-filter').style.display = "block";
-  document.getElementById('js-turned-off').style.display = "none";
+    /* end code taken from Inclusive Components */
 
-  jQuery(document).ready(function ($) {
 
     var checkedValues = [];
 
@@ -79,5 +85,5 @@ if (evidencePage) {
         }
       });
     }
-  });
-}
+  }
+});

--- a/web/app/themes/brookhouse/assets/scss/evidence.scss
+++ b/web/app/themes/brookhouse/assets/scss/evidence.scss
@@ -60,6 +60,10 @@
     width: 100rem;
     vertical-align: top;
 
+    &.govuk-fieldset {
+      margin-top: 2rem;
+    }
+
     @media screen and (min-width: 400px) {
       width: 30%;
       display: inline-block;

--- a/web/app/themes/brookhouse/assets/scss/main-nav.scss
+++ b/web/app/themes/brookhouse/assets/scss/main-nav.scss
@@ -5,7 +5,6 @@
   position: fixed;
   z-index: 6;
   width: 100%;
-  background: $white;
 
   @media screen and (min-width: 770px) {
     background: none;
@@ -30,8 +29,9 @@
     -o-transition: .5s ease-in-out;
     transition: .5s ease-in-out;
     cursor: pointer;
-    background: none;
-    border: none;
+    background: $white;
+    border: 0.5rem solid white;
+    border-bottom: 0;
     box-sizing: border-box;
     height: 22px;
     float: right;

--- a/web/app/themes/brookhouse/page-evidence-listing.php
+++ b/web/app/themes/brookhouse/page-evidence-listing.php
@@ -16,10 +16,11 @@ get_header();
 
             <?php $query = new WP_Query( array( 'post_type' => 'evidence', 'paged' => $paged, 'orderby'   => 'meta_value_num', 'meta_key'  => 'evidence_publish_date' ) ); ?>
 
-            <p id="js-turned-off"><?php _e('Please turn JavaScript on in your browser, to enable the filter functionality.', 'brookhouse'); ?></p>
-            <div id="js-evidence-filter">
-                <p><?php _e('Select the categories that you would like to see.', 'brookhouse'); ?></p>
-                    <div class="evidence__filter">
+            <?php if ( $query->have_posts() ) : ?>
+                <p id="js-turned-off"><?php _e('Please turn JavaScript on in your browser, to enable the filter functionality.', 'brookhouse'); ?></p>
+                <div id="js-evidence-filter">
+                    <p><?php _e('Select the categories that you would like to see.', 'brookhouse'); ?></p>
+                        <div class="evidence__filter">
 
                         <?php
                             $evidenceType = get_terms('evidence-type');
@@ -86,16 +87,15 @@ get_header();
                     </div>
                 </div>
 
-                <ul class="evidence__list" role="region" id="aria-evidence-updates" aria-live="polite">
-                <?php
-                    if ( $query->have_posts() ) :
-                        while ( $query->have_posts() ) : $query->the_post();
-                            include(locate_template('content-evidence-list-item.php', false, false));
-                        endwhile; wp_reset_postdata();
-                        else :
-                    endif;
-                ?>
-            </ul>
+                    <ul class="evidence__list" role="region" id="aria-evidence-updates" aria-live="polite">
+                    <?php
+                            while ( $query->have_posts() ) : $query->the_post();
+                                include(locate_template('content-evidence-list-item.php', false, false));
+                            endwhile; wp_reset_postdata();
+                            else :
+                        ?>
+                    </ul>
+             <?php endif; ?>
         <?php endwhile; // end of the loop. ?>
     </main>
 </div>

--- a/web/app/themes/brookhouse/page-evidence-listing.php
+++ b/web/app/themes/brookhouse/page-evidence-listing.php
@@ -8,7 +8,7 @@ get_header();
 <?php get_sidebar(); ?>
 
 <div id="primary" class="content-area">
-    <main id="main" class="site-main documents-main">
+    <main id="main" class="site-main evidence-main">
         <?php while (have_posts()) : the_post(); ?>
 
             <h1><?php the_title(); ?></h1>


### PR DESCRIPTION
This PR prevents filter table from showing if there are no evidence items to show. It also prevents the evidence page JS from running on other pages.

This also adds more spacing to fieldsets on mobile, to make legend labelling clearer, and changes t he hamburger white background to just cover the hamburger button, so other page content isn't obscured.