### PR TITLE
removed hearing location address

### DIFF
--- a/web/app/themes/brookhouse/single-hearings.php
+++ b/web/app/themes/brookhouse/single-hearings.php
@@ -36,18 +36,6 @@ get_sidebar();
 
     include(locate_template('components/hearing-link-section.php', false, false)); ?>
 
-    <h3>Hearing location</h3>
-
-    <address>
-    Brook House Inquiry<br>
-    The International Dispute Resolution Centre<br>
-    70 Fleet Street<br>
-    London<br>
-    EC4Y 1EU<br>
-    </address>
-
-    <a href="https://www.google.com/maps/place/International+Dispute+Resolution+Centre+Ltd/@51.5139923,-0.1094127,17z/data=!3m1!4b1!4m5!3m4!1s0x487604b2b87d2383:0x3ef3ecd74c455098!8m2!3d51.513989!4d-0.107224">Find on Google maps</a>
-
     </main><!-- #main -->
 </div><!-- #primary -->
 


### PR DESCRIPTION
Brookhouse Enquiry stakeholders have asked us to remove the Hearing location address from the hearing page template.