### PR TITLE
Add Table styles

### DIFF
--- a/web/app/themes/brookhouse/assets/scss/general.scss
+++ b/web/app/themes/brookhouse/assets/scss/general.scss
@@ -188,6 +188,22 @@ article {
         vertical-align: middle;
       }
     }
+      .wp-block-table:not(.is-style-stripes) table {
+          border: 1px solid;
+
+          th,td {
+              &:not(:last-child) {
+                  border-right: 1px solid $grey-dark;
+              }
+          }
+          th,
+          tr:not(:last-child) td{
+              border-bottom: 1px solid $grey-dark;
+          }
+          tfoot td {
+              border-top: 1px solid $grey-dark;
+          }
+      }
   }
 }
 


### PR DESCRIPTION
Add table styles to table block.
I have used a :not here as this block does not always have a additional style class. 
There are only two styles currently. Default and striped.
We could look at adding the table style of the hearings table